### PR TITLE
Updating Apache2 log to use the reverse proxy IP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -104,6 +104,10 @@ RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli
 # Developer assistance
 RUN echo "alias wp='wp --allow-root' >> ~/.bashrc"
 
+# Hack apache2.conf to use the X-Forwarded-For header.
+# This is important when running behind a revers proxy. If you are not behind a reverse proxy, this step may be uneccessary.
+RUN sed -i "s/%h/%{X-Forwarded-For}i/g" /etc/apache2/apache2.conf
+
 # Cleanup
 RUN rm -rf /usr/src/*
 


### PR DESCRIPTION
Apache2 was only showing the IP of the proxy in log files. This update
changes that so that it will use the IP that is passed in the
X-Forwarded-For header